### PR TITLE
22 bug: update populate_job_titles

### DIFF
--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -283,21 +283,10 @@ def _populate_job_titles(nodes: list, soc_index: pd.DataFrame):
     """Populate job titles. Modifies nodes in places."""
     for node in nodes:
         if SocCode(node.soc_code).code_length() == _SOC_CODE_LENGTH:
-            filtered_index = soc_index[soc_index["soc_2020"] == str(node.soc_code)]
+            filtered_index = soc_index[soc_index["code"] == str(node.soc_code)]
 
             for _index, row in filtered_index.iterrows():
-
-                job_title = ""
-
-                if pd.notna(row["add"]):
-                    job_title += f"{row['add']} "
-
-                job_title += row["natural_word"]
-
-                if pd.notna(row["ind"]):
-                    job_title += f" ({row['ind']})"
-
-                node.job_titles.append(job_title)
+                node.job_titles.append(row["title"])
 
 
 def is_leaf_code(code) -> bool:


### PR DESCRIPTION
## ✨ Summary

Fixed an issue that arose after making changes in soc_data_access. Closes #22 

## 📜 Changes Introduced

- [ ] Bug fix: fixed an issue with populate_job_titles - it was using old schema for soc_index, which caused issues when running load_hierarchy() in soc_hierarchy.py
- [ ] Bug fix: rename column names used when reading data ('soc2020' -> 'code')
## ✅ Checklist

- [v] Code is formatted using **Black**
- [v] Imports are sorted using **isort**
- [v] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [v] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [v] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

Use load_hierarchy()
