### PR TITLE
26 refactor hierarchy use meta

### DIFF
--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -250,7 +250,9 @@ def _define_codes_and_nodes(soc_df: pd.DataFrame):
     for code in soc_df["code"]:
         group_description = soc_meta.get_meta_by_code(code)["group description"]
         group_title = soc_meta.get_meta_by_code(code)["group title"]
-        soc_node = SocNode(code, group_title=group_title, group_description=group_description)
+        soc_node = SocNode(
+            code, group_title=group_title, group_description=group_description
+        )
 
         codes.append(code)
         nodes.append(soc_node)
@@ -267,16 +269,19 @@ def _populate_parent_child_relationships(nodes: list, code_node_dict: dict):
             code_node_dict[node.soc_code].parent = code_node_dict[parent_code]
 
 
-def _populate_tasks_and_quals(nodes: list, soc_df: pd.DataFrame):
+def _populate_tasks_and_quals(nodes: list):
     """Populate tasks and qualifications. Modifies nodes in places."""
+    soc_meta = SocMeta()
     for node in nodes:
-        if SocCode(node.soc_code).code_length() == _SOC_CODE_LENGTH:
-            qual = soc_df.loc[soc_df["code"] == node.soc_code, "qualifications"]
-            node.qualifications = qual.iloc[0]
+        code = node.soc_code
+        if SocCode(code).code_length() == _SOC_CODE_LENGTH:
+            qual = soc_meta.get_meta_by_code(code)[
+                "typical entry routes and associated qualifications"
+            ]
+            node.qualifications = qual
 
-            tasks = soc_df.loc[soc_df["code"] == node.soc_code, "tasks"]
-            tasks_list = tasks.iloc[0].replace("\n", "").split("~")
-
+            tasks = soc_meta.get_meta_by_code(code)["tasks"]
+            tasks_list = tasks.replace("\n", "").split("~")
             node.tasks = tasks_list[1:]
 
 
@@ -319,7 +324,7 @@ def load_hierarchy(soc_df, soc_index):
 
     _populate_parent_child_relationships(nodes, code_node_dict)
 
-    _populate_tasks_and_quals(nodes, soc_df)
+    _populate_tasks_and_quals(nodes)
 
     _populate_job_titles(nodes, soc_index)
 

--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -248,8 +248,8 @@ def _define_codes_and_nodes(soc_df: pd.DataFrame):
     code_node_dict = {}
 
     for code in soc_df["code"]:
-        group_description = soc_meta.get_meta_by_code("1")["group description"]
-        group_title = soc_meta.get_meta_by_code("1")["group title"]
+        group_description = soc_meta.get_meta_by_code(code)["group description"]
+        group_title = soc_meta.get_meta_by_code(code)["group title"]
         soc_node = SocNode(code, group_title=group_title, group_description=group_description)
 
         codes.append(code)

--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -248,8 +248,8 @@ def _define_codes_and_nodes(soc_df: pd.DataFrame):
     code_node_dict = {}
 
     for code in soc_df["code"]:
-        group_description = soc_meta.get_meta_by_code(code)["group description"]
-        group_title = soc_meta.get_meta_by_code(code)["group title"]
+        group_description = soc_meta.get_meta_by_code(code)["group_description"]
+        group_title = soc_meta.get_meta_by_code(code)["group_title"]
         soc_node = SocNode(
             code, group_title=group_title, group_description=group_description
         )
@@ -276,7 +276,7 @@ def _populate_tasks_and_quals(nodes: list):
         code = node.soc_code
         if SocCode(code).code_length() == _SOC_CODE_LENGTH:
             qual = soc_meta.get_meta_by_code(code)[
-                "typical entry routes and associated qualifications"
+                "typical_entry_routes_and_associated_qualifications"
             ]
             node.qualifications = qual
 

--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -6,6 +6,8 @@ Usage: provides information regarding the specified code.
 
 import pandas as pd
 
+from occupational_classification.meta.soc_meta import SocMeta
+
 _LEVEL_DICT = {1: "Major", 2: "Sub-Major", 3: "Minor", 4: "Unit"}
 _SOC_CODE_LENGTH = 4
 
@@ -239,17 +241,16 @@ def _define_codes_and_nodes(soc_df: pd.DataFrame):
     """Creates codes list, nodes list and code_node_dict dictionary,
     later used for SOC.
     """
+    soc_meta = SocMeta()
     codes = []
     nodes = []
 
     code_node_dict = {}
 
-    for code, group_title, group_description in soc_df[
-        ["code", "soc2020_group_title", "group_description"]
-    ].itertuples(index=False, name=None):
-        soc_node = SocNode(
-            code, group_description=group_description, group_title=group_title
-        )
+    for code in soc_df["code"]:
+        group_description = soc_meta.get_meta_by_code("1")["group description"]
+        group_title = soc_meta.get_meta_by_code("1")["group title"]
+        soc_node = SocNode(code, group_title=group_title, group_description=group_description)
 
         codes.append(code)
         nodes.append(soc_node)

--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -276,7 +276,7 @@ def _populate_tasks_and_quals(nodes: list):
         code = node.soc_code
         if SocCode(code).code_length() == _SOC_CODE_LENGTH:
             qual = soc_meta.get_meta_by_code(code)[
-                "typical_entry_routes_and_associated_qualifications"
+                "entry_routes_and_quals"
             ]
             node.qualifications = qual
 

--- a/src/occupational_classification/meta/soc_meta.py
+++ b/src/occupational_classification/meta/soc_meta.py
@@ -105,7 +105,7 @@ class SocMeta:
                     "code": element.get("code", None),
                     "group_title": element.get("soc2020_group_title", None),
                     "group_description": element.get("group_description", None),
-                    "typical_entry_routes_and_associated_qualifications": element.get(
+                    "entry_routes_and_quals": element.get(
                         "qualifications", []
                     ),
                     "tasks": element.get("tasks", []),

--- a/src/occupational_classification/meta/soc_meta.py
+++ b/src/occupational_classification/meta/soc_meta.py
@@ -75,10 +75,11 @@ class SocDB:
 
 
 class SocMeta:
-    """SOC Meta data model class for SOC codes and their descriptions
-    build based on java dictionary from onsdigital repo.
+    """SOC Meta data model class for SOC codes and their desriptions.
+    Load and manage data related to SOC codes.
 
     Attributes:
+        df (pd.DataFrame): DataFrame containing data for SOC structure.
         soc_meta (List[ClassificationMeta]): List of ClassificationMeta objects
     """
 
@@ -90,7 +91,7 @@ class SocMeta:
         self.soc_meta = SocDB(self.df).create_soc_dictionary()
 
     def get_meta_by_code(self, code: str) -> dict:
-        """Retrieve title and detail for a given SOC code.
+        """Retrieve title and details for a given SOC code.
 
         Args:
             code (str): A SOC code to lookup.
@@ -99,15 +100,15 @@ class SocMeta:
             dict: Dictionary with title and detail if found, else an error message.
         """
         for element in self.soc_meta:
-            if element["code"].startswith(code):
+            if element["code"] == code:
                 return {
                     "code": element.get("code", None),
                     "group title": element.get("soc2020_group_title", None),
                     "group description": element.get("group_description", None),
                     "typical entry routes and associated qualifications": element.get(
-                        "tasks", []
+                        "qualifications", []
                     ),
-                    "tasks": element.get("qualifications", []),
+                    "tasks": element.get("tasks", []),
                 }
 
         # No match found

--- a/src/occupational_classification/meta/soc_meta.py
+++ b/src/occupational_classification/meta/soc_meta.py
@@ -103,9 +103,9 @@ class SocMeta:
             if element["code"] == code:
                 return {
                     "code": element.get("code", None),
-                    "group title": element.get("soc2020_group_title", None),
-                    "group description": element.get("group_description", None),
-                    "typical entry routes and associated qualifications": element.get(
+                    "group_title": element.get("soc2020_group_title", None),
+                    "group_description": element.get("group_description", None),
+                    "typical_entry_routes_and_associated_qualifications": element.get(
                         "qualifications", []
                     ),
                     "tasks": element.get("tasks", []),

--- a/src/occupational_classification/meta/soc_meta.py
+++ b/src/occupational_classification/meta/soc_meta.py
@@ -8,6 +8,7 @@ for given SOC codes.
 
 import pandas as pd
 
+from occupational_classification.data_access.soc_data_access import load_soc_structure
 from occupational_classification.meta.classification_meta import ClassificationMeta
 
 
@@ -81,6 +82,33 @@ class SocMeta:
         soc_meta (List[ClassificationMeta]): List of ClassificationMeta objects
     """
 
-    def __init__(self, df: pd.DataFrame):
-        self.df = df
+    def __init__(
+        self,
+        data_path: str = "../src/occupational_classification/data/soc2020volume1structureanddescriptionofunitgroupsexcel16042025.xlsx",
+    ):
+        self.df = load_soc_structure(data_path)
         self.soc_meta = SocDB(self.df).create_soc_dictionary()
+
+    def get_meta_by_code(self, code: str) -> dict:
+        """Retrieve title and detail for a given SOC code.
+
+        Args:
+            code (str): A SOC code to lookup.
+
+        Returns:
+            dict: Dictionary with title and detail if found, else an error message.
+        """
+        for element in self.soc_meta:
+            if element["code"].startswith(code):
+                return {
+                    "code": element.get("code", None),
+                    "group title": element.get("soc2020_group_title", None),
+                    "group description": element.get("group_description", None),
+                    "typical entry routes and associated qualifications": element.get(
+                        "tasks", []
+                    ),
+                    "tasks": element.get("qualifications", []),
+                }
+
+        # No match found
+        return {"error": f"No metadata found for SOC code {code}"}


### PR DESCRIPTION
## ✨ Summary

Changes to soc_hierarchy to use SocMeta().soc_meta for SocNode attributes. Issue #26 

## 📜 Changes Introduced

- [ ] Refactoring: use SocMeta().soc_meta to access attributes: group_title, group_description, tasks, and qualifications.
- [ ] Use concise name for dictionary keys. 


## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ v ] Code is formatted using **Black**
- [ v ] Imports are sorted using **isort**
- [ v ] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [ v ] Security checks pass using **Bandit**
- [ v ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ v ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

Accessing and modifying data:
`soc_df_input = load_soc_structure(soc_structure_file)`
`soc_df = soc_meta.create_soc_dataframe(soc_df_input)`
`soc_index = load_soc_index(soc_index_file)`,
where soc_structure_file and soc_index_file are files containing SOC structure, and SOC index respectively. ([soc_structure](https://github.com/user-attachments/assets/a2b342c6-e997-4717-bb45-3d24d479e0a9), [soc_index](https://github.com/user-attachments/assets/a11837a9-d62b-49e8-8299-1d07c935f18e)).

Main usage:
`soc = soc_hierarchy.load_hierarchy(soc_df, soc_index)`
Use `soc.all_leaf_text()` to access a DF with codes and their corresponding information.
