### PR TITLE
Fix data access for soc-classification-utils

### DIFF
--- a/src/occupational_classification/_config/main.py
+++ b/src/occupational_classification/_config/main.py
@@ -60,7 +60,7 @@ def check_file_exists(  # noqa: PLR0911
         if path.exists():
             return path
     with resources.as_file(
-        resources.files("occupational_classification.data").joinpath(str(file_path))
+        resources.files("occupational_classification._config").joinpath(str(file_path))
     ) as path:
         if path.exists():
             return path

--- a/src/occupational_classification/_config/main.py
+++ b/src/occupational_classification/_config/main.py
@@ -20,9 +20,9 @@ logger = logging.getLogger(__name__)
 _config = None
 
 
-def check_file_exists(
+def check_file_exists(  # noqa: PLR0911
     file_name: Optional[Union[Path, str]] = "config.toml",
-) -> Path:
+) -> Optional[Path]:
     """Check if the file exists.
 
     If relative path provided it will look for the file in these locations:
@@ -38,7 +38,7 @@ def check_file_exists(
     Returns:
         Path: The absolute path to the file if it exists, None otherwise.
     """
-    file_path = Path(file_name)
+    file_path = Path(file_name)  # type: ignore
     # check whether the filepath is relative or absolute
     if file_path.is_absolute():
         return file_path if file_path.exists() else None
@@ -52,14 +52,20 @@ def check_file_exists(
     elif (Path.home() / file_path).exists():
         return Path.home() / file_path
     # check whether the file exists in the package resources
-    elif (resources.files("occupational_classification._config") / file_path).exists():
-        return resources.files("occupational_classification._config") / file_path
-    elif (
-        resources.files("occupational_classification.example_data") / file_path
-    ).exists():
-        return resources.files("occupational_classification.example_data") / file_path
-    else:
-        return None
+    with resources.as_file(
+        resources.files("occupational_classification.example_data").joinpath(
+            str(file_path)
+        )
+    ) as path:
+        if path.exists():
+            return path
+    with resources.as_file(
+        resources.files("occupational_classification.data").joinpath(str(file_path))
+    ) as path:
+        if path.exists():
+            return path
+    # else:
+    return None
 
 
 def get_config(config_name: Optional[Union[Path, str]] = "config.toml") -> dict:
@@ -79,7 +85,7 @@ def get_config(config_name: Optional[Union[Path, str]] = "config.toml") -> dict:
     Raises:
         FileNotFoundError: If the config file or required data not found.
     """
-    global _config
+    global _config  # noqa: PLW0603
 
     if _config is None:
         config_filepath = check_file_exists(config_name)

--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -4,7 +4,7 @@ Usage: provides information regarding the specified code.
     soc["1"].
 """
 
-from typing import Union
+from typing import Union, Optional
 
 import pandas as pd
 
@@ -304,7 +304,7 @@ def find_parent(code) -> Union[str, None]:
 def load_hierarchy(
     soc_df,
     soc_index,
-    structure_data_path: str = ""
+    structure_data_path: Optional[str] = None
 ):
     """Create the SOC lookups from all supporting data.
 
@@ -315,7 +315,7 @@ def load_hierarchy(
     Once created this provides a single point of access for all
     data associated with a SOC definition.
     """
-    if structure_data_path == "":
+    if structure_data_path is None:
         structure_data_path = get_config()["data_source"]["soc_structure"]
     codes, nodes, code_node_dict = _define_codes_and_nodes(
         soc_df, structure_data_path=structure_data_path

--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -302,8 +302,8 @@ def find_parent(code) -> Union[str, None]:
 
 
 def load_hierarchy(
-    soc_df,
-    soc_index,
+    soc_df: pd.DataFrame,
+    soc_index: pd.DataFrame,
     structure_data_path: Optional[str] = None
 ):
     """Create the SOC lookups from all supporting data.

--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -304,7 +304,7 @@ def find_parent(code) -> Union[str, None]:
 def load_hierarchy(
     soc_df,
     soc_index,
-    structure_data_path: str = get_config()["data_source"]["soc_structure"],
+    structure_data_path: str = ""
 ):
     """Create the SOC lookups from all supporting data.
 

--- a/src/occupational_classification/lookup/soc_lookup.py
+++ b/src/occupational_classification/lookup/soc_lookup.py
@@ -203,7 +203,7 @@ class SOCRephraseLookup:
     """
 
     def __init__(self):
-        self.meta: SocMeta = SocMeta()
+        self.meta: SocMeta = SocMeta(structure_data_path = get_config()["data_source"]["soc_structure"])
 
         self.lookup_dict: dict[str, str] = {
             item["code"]: item["soc2020_group_title"] for item in self.meta.soc_meta

--- a/src/occupational_classification/lookup/soc_lookup.py
+++ b/src/occupational_classification/lookup/soc_lookup.py
@@ -52,7 +52,7 @@ class SOCLookup:
         self.lookup_dict: dict[str, str] = self.data.set_index("description").to_dict()[
             "label"
         ]
-        self.meta: SocMeta = SocMeta()
+        self.meta: SocMeta = SocMeta(get_config()["data_source"]["soc_structure"])
 
     def data_preparation(self, data_path):
         """Converts the data for useful format for lookup method.

--- a/src/occupational_classification/meta/soc_meta.py
+++ b/src/occupational_classification/meta/soc_meta.py
@@ -8,7 +8,6 @@ for given SOC codes.
 
 import pandas as pd
 
-from occupational_classification._config.main import get_config
 from occupational_classification.data_access.soc_data_access import load_soc_structure
 from occupational_classification.meta.classification_meta import ClassificationMeta
 
@@ -92,11 +91,8 @@ class SocMeta:
         soc_meta (List[ClassificationMeta]): List of ClassificationMeta objects
     """
 
-    def __init__(
-        self,
-        data_path: str = get_config()["data_source"]["soc_structure"],
-    ):
-        self.df = load_soc_structure(data_path)
+    def __init__(self, structure_data_path: str):
+        self.df = load_soc_structure(structure_data_path)
         self.soc_meta = SocDB(self.df).create_soc_dictionary()
 
     def get_meta_by_code(self, code: str) -> dict:

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,3 +1,4 @@
+# pylint: disable=C0301
 import pytest
 
 from src.occupational_classification.lookup import soc_lookup


### PR DESCRIPTION
## ✨ Summary

Changes to the method of initializing SocMeta in soc-classification-library, required to enable usage in soc-classification-utils as a package. The main change includes enabling specifying structure_data_path when calling load_hierarchy from hierarchy/soc_hierarchy.py.

In SocMeta - removed default value for data_path. Now to call SocMeta, a path to the file containing SOC structure data needs to be provided, i.e. SocMeta("path/to/the/file").

Previously load_hierarchy was taking two arguments: soc_df and soc_index.
Currently load_hierarchy takes soc_df, soc_index, and structure_data_path, however, if structure_data_path is not specified, the path will be set to use value from config.

## 📜 Changes Introduced

- Introduce structure_data_path argument in load_hierarchy.
- Changes to the code to reflect changed load_hierarchy method.
- Remove default value for data_path in SocMeta to avoid using path from congif, in case when calling SocMeta as part of soc-classification-library package.

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ ] Code is formatted using **Black**
- [ ] Imports are sorted using **isort**
- [ ] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

To test please run:
`poetry run python src/occupational_classification/lookup/soc_lookup_example.py `
`pytest tests/test_lookup.py`
`pytest tests/test_data_access.py`
`pytest tests/test_soc_data_structure.py`