### PR TITLE
Sa 575/soc rephrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Standard Occupational Classification (SOC) Library, initially developed for Surv
 
 ## Overview
 
-SOC classification library, utilities used to classify occupation code based off of ${\small\color{red}\text{TODO}}$.
+SOC classification library, utilities used to classify occupation code based off the
+official ONS SOC 2020 structure and coding index.
 
 ## Features
 
 - SOC Lookup.  A utility that uses a well-known set of SOC mappings of job titles to SOC classification codes.
 - SOC Classification. A RAG approach to classification of SOC using input data, semantic search and LLM.
+ - SOC Rephrase. Packaged example data and `SOCRephraseLookup` for mapping `soc_code` values to respondent-friendly rephrased descriptions.
 
 ## Prerequisites
 
@@ -77,9 +79,7 @@ make check-python
 
 ### Documentation
 
-Documentation is available in the docs folder and can be viewed using mkdocs
-
-${\small\color{red}\text{TODO: write documentation}}$
+Documentation is available in the `docs/` folder and can be viewed using mkdocs:
 
 ```bash
 make run-docs
@@ -103,4 +103,6 @@ make all-tests
 
 ### Environment Variables
 
-${\small\color{red}\text{TODO}}$
+This library is designed to be consumed as a Python package and does not require
+any environment variables on its own. Downstream services (such as `survey-assist-api`)
+may define their own configuration around it.

--- a/docs/example_data.md
+++ b/docs/example_data.md
@@ -1,21 +1,40 @@
 # Example Data
 
-Snippets of example data, useful for testing and understanding format, are detailed below.
-
-${\small\color{red}\text{TODO: signpost to data sets}}$
+Snippets of example data, useful for testing and understanding format, are detailed below. For full source data, see the SOC 2020 releases linked from `docs/index.md`.
 
 ## Example SOC Lookup Data
 
-${\small\color{red}\text{TODO}}$
+The SOC lookup examples are derived from the ONS SOC 2020 coding index and structure
+files (see `docs/index.md`). The library ships with a small, self-contained slice of
+that data to exercise the lookup and hierarchy APIs.
 
 ### SOC Lookup - Example Rows
 
-${\small\color{red}\text{TODO}}$
+Typical lookup rows contain:
+
+- **code**: SOC 2020 unit group code (for example `1111`)
+- **title**: example job title (for example `Chief executives and senior officials`)
+
+This data is exposed via `load_soc_index(...)` and used by `SOCLookup` to build an
+exact-match dictionary from lowercased job titles to SOC codes.
 
 ## Example Rephrased SOC Data
 
-${\small\color{red}\text{TODO}}$
+The library also includes an example SOC rephrase dataset in:
+
+- `src/occupational_classification/example_data/example_rephrased_soc_data.csv`
+
+This CSV is intentionally small and is designed for testing and demonstrations rather
+than full SOC 2020 coverage.
 
 ### Rephrased SOC - Example Rows
 
-${\small\color{red}\text{TODO}}$
+Each row in the rephrase CSV contains:
+
+- **soc_code**: SOC 2020 code as a string (for example `1111`)
+- **rephrased_description**: a shorter, respondent-friendly description for that code
+  (for example “Senior officials and executives”).
+
+`SOCRephraseLookup` loads this file and exposes a simple `lookup(soc_code)` method and
+`process_json(...)` helper, which are consumed by `survey-assist-api` to attach
+rephrased SOC descriptions to classification responses.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -27,5 +27,8 @@ poetry add git+https://github.com/ONSdigital/soc-classification-library.git@v.0.
 
 ### Usage
 
-Example code that uses the SOC Lookup and implicitly the SOC Meta code is available in soc_lookup_example.py ${\small\color{red}\text{(TODO)}}$
+Example code that uses the SOC lookup and SOC meta functionality is available in `src/occupational_classification/lookup/soc_lookup_example.py`. Run it with:
 
+```bash
+poetry run python src/occupational_classification/lookup/soc_lookup_example.py
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,3 +10,4 @@ The SOC hierarchy object is built using two public data sources provided by ONS:
 ## Available Utilities
 
 - [SOC Lookup](guide.md): Lookup SOC from a well known list of occupations.
+- SOC rephrase support: packaged example data and `SOCRephraseLookup` for mapping `soc_code` values to respondent-friendly rephrased descriptions.

--- a/notebooks/soc_2025_05_01.py
+++ b/notebooks/soc_2025_05_01.py
@@ -1,3 +1,7 @@
+"""Example usage of SOC hierarchy, lookup, and rephrase."""
+
+# pylint: disable=line-too-long,pointless-statement
+
 # %% [markdown]
 # # Provide a simple example on the usage of files.
 
@@ -50,7 +54,8 @@ hierarchy.all_leaf_text()
 # Access specific attributes of hierarchy (from soc_code, group_title, group_description, group_level, tasks, parent, children, qualifications, job_titles)
 
 # %%
-hierarchy["1111"].job_titles
+job_titles_1111 = hierarchy["1111"].job_titles
+print(job_titles_1111)
 
 # %% [markdown]
 # ## Create a lookup, for identical matches
@@ -87,7 +92,12 @@ soc_lookup.lookup_code_major_group("2112")
 
 # %%
 soc_lookup.unique_code_major_group(
-    [{"soc_code": "1111"}, {"soc_code": "2111"}, {"soc_code": "9265"}, {"soc_code": "41"}]
+    [
+        {"soc_code": "1111"},
+        {"soc_code": "2111"},
+        {"soc_code": "9265"},
+        {"soc_code": "41"},
+    ]
 )
 
 # %% [markdown]
@@ -113,7 +123,7 @@ input_json = {
 processed_json = rephrased_soc.process_json(input_json)
 
 # %%
-processed_json
+print(processed_json)
 
 # %% [markdown]
 # ## Other methods to access meta
@@ -138,5 +148,3 @@ soc_lookup.meta.get_meta_by_code("2431")
 
 # %% [markdown]
 # # Misc
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "soc-classification-library"
-version = "0.1.2"
+version = "0.1.3"
 description = "Standard Occupational Classification library"
 authors = ["Steve Gibbard <steve.gibbard@ons.gov.uk>"]
 license = "MIT"

--- a/src/occupational_classification/_config/main.py
+++ b/src/occupational_classification/_config/main.py
@@ -17,10 +17,10 @@ from pyprojroot import here
 
 logger = logging.getLogger(__name__)
 
-_config = None
+_config = None  # pylint: disable=invalid-name
 
 
-def check_file_exists(  # noqa: PLR0911
+def check_file_exists(  # noqa: PLR0911  # pylint: disable=too-many-return-statements
     file_name: Optional[Union[Path, str]] = "config.toml",
 ) -> Optional[Path]:
     """Check if the file exists.
@@ -43,13 +43,13 @@ def check_file_exists(  # noqa: PLR0911
     if file_path.is_absolute():
         return file_path if file_path.exists() else None
     # check whether the file exists in the current directory
-    elif (Path.cwd() / file_path).exists():
+    if (Path.cwd() / file_path).exists():
         return Path.cwd() / file_path
     # check whether the file exists in the project root directory
-    elif (Path(here()) / file_path).exists():
+    if (Path(here()) / file_path).exists():
         return Path(here()) / file_path
     # check whether the file exists in the user's home directory
-    elif (Path.home() / file_path).exists():
+    if (Path.home() / file_path).exists():
         return Path.home() / file_path
     # check whether the file exists in the package resources
     with resources.as_file(
@@ -85,31 +85,28 @@ def get_config(config_name: Optional[Union[Path, str]] = "config.toml") -> dict:
     Raises:
         FileNotFoundError: If the config file or required data not found.
     """
-    global _config  # noqa: PLW0603
+    global _config  # noqa: PLW0603  # pylint: disable=global-statement
 
     if _config is None:
         config_filepath = check_file_exists(config_name)
 
         if config_filepath is None:
             raise FileNotFoundError("Config file not found.")
-        else:
-            with open(config_filepath) as f:
-                logger.info(f"Loading config from {config_filepath}")
-                in_config = toml.load(f)
-            for key, soc_data in in_config["data_source"].items():
-                soc_data_path = check_file_exists(soc_data)
-                if soc_data_path is None:
-                    if key in ["soc_index", "soc_structure"]:
-                        raise FileNotFoundError(
-                            f"Required soc_data file {key}: {soc_data} not found."
-                        )
-                    else:
-                        logger.warning(
-                            f"Optional lookup file {key}: {soc_data} not found."
-                        )
-                else:
-                    in_config["data_source"][key] = soc_data_path
-            _config = in_config
-            logger.debug(f"Config values: {_config}")
+
+        with open(config_filepath, encoding="utf-8") as f:
+            logger.info("Loading config from %s", config_filepath)
+            in_config = toml.load(f)
+        for key, soc_data in in_config["data_source"].items():
+            soc_data_path = check_file_exists(soc_data)
+            if soc_data_path is None:
+                if key in ["soc_index", "soc_structure"]:
+                    raise FileNotFoundError(
+                        f"Required soc_data file {key}: {soc_data} not found."
+                    )
+                logger.warning("Optional lookup file %s: %s not found.", key, soc_data)
+            else:
+                in_config["data_source"][key] = soc_data_path
+        _config = in_config
+        logger.debug("Config values: %s", _config)
 
     return _config

--- a/src/occupational_classification/example_data/example_rephrased_soc_data.csv
+++ b/src/occupational_classification/example_data/example_rephrased_soc_data.csv
@@ -1,0 +1,7 @@
+soc_code,rephrased_description
+1111,Senior officials and managers
+1112,Production or operations managers
+1121,Finance managers
+2136,Programmers and software development professionals
+9233,Cleaners and domestics
+

--- a/src/occupational_classification/example_data/example_rephrased_soc_data.csv
+++ b/src/occupational_classification/example_data/example_rephrased_soc_data.csv
@@ -4,4 +4,6 @@ soc_code,rephrased_description
 1121,Finance managers
 2136,Programmers and software development professionals
 9233,Cleaners and domestics
+1131,Heads of finance and financial strategy
+3534,Managers of company financial accounts
 

--- a/src/occupational_classification/hierarchy/soc_hierarchy.py
+++ b/src/occupational_classification/hierarchy/soc_hierarchy.py
@@ -4,7 +4,7 @@ Usage: provides information regarding the specified code.
     soc["1"].
 """
 
-from typing import Union, Optional
+from typing import Optional, Union
 
 import pandas as pd
 
@@ -35,6 +35,7 @@ class SocCode:
         self.level_name = _LEVEL_DICT
 
     def code_length(self):
+        """Return the number of digits in the SOC code."""
         return len(self.code)
 
     @staticmethod
@@ -72,7 +73,7 @@ class SocCode:
         return group
 
 
-class SocNode:
+class SocNode:  # pylint: disable=too-many-instance-attributes
     """Creates a SOC object that is used for hierarchy operations."""
 
     def __init__(self, soc_code: str, group_title: str, group_description: str):
@@ -121,11 +122,11 @@ class SocNode:
     def print_all(self):
         """Prints all information about the SOC hierarchy.
         - code as "Code": A 1, 2, 3, or 4 digit code identifying group.
-        - soc2020_group_title as "Group Title": A short group title for the group code in SOC 2020.
-        - parent (if applicable) as Parent:  a code for parnt, followed with the group title.
-        - group_description as "Group Description": More in-depth description of the group.
-        - children (if applicable) as Children: a code for children, followed with the group title.
-        - tasks (if applicable) as Tasks: A list of tasks that are typically associated with the Unit group.
+        - soc2020_group_title as "Group Title": short SOC 2020 group title.
+        - parent (if applicable) as Parent: parent code and title.
+        - group_description as "Group Description": longer description text.
+        - children (if applicable) as Children: child codes and titles.
+        - tasks (if applicable) as Tasks: list of tasks for the Unit group.
         """
         print(f"SOC Code: {self.soc_code}")
         print(f"\nGroup Level: {self.group_level}")
@@ -232,8 +233,9 @@ class SOC:
 
 
 def _define_codes_and_nodes(soc_df: pd.DataFrame, structure_data_path: str):
-    """Creates codes list, nodes list and code_node_dict dictionary,
-    later used for SOC.
+    """Creates codes list, nodes list and code_node_dict dictionary.
+
+    Later used for SOC.
     """
     soc_meta = SocMeta(structure_data_path=structure_data_path)
     codes = []
@@ -297,14 +299,13 @@ def find_parent(code) -> Union[str, None]:
         n_digits = SocCode(code).code_length()
         code = str(code)
         return code[0 : n_digits - 1]
-    else:
-        return None
+    return None
 
 
 def load_hierarchy(
     soc_df: pd.DataFrame,
     soc_index: pd.DataFrame,
-    structure_data_path: Optional[str] = None
+    structure_data_path: Optional[str] = None,
 ):
     """Create the SOC lookups from all supporting data.
 
@@ -317,7 +318,7 @@ def load_hierarchy(
     """
     if structure_data_path is None:
         structure_data_path = get_config()["data_source"]["soc_structure"]
-    codes, nodes, code_node_dict = _define_codes_and_nodes(
+    _codes, nodes, code_node_dict = _define_codes_and_nodes(
         soc_df, structure_data_path=structure_data_path
     )
 

--- a/src/occupational_classification/lookup/soc_lookup.py
+++ b/src/occupational_classification/lookup/soc_lookup.py
@@ -17,6 +17,8 @@ Classes:
 
 from typing import Any, Optional, Union
 
+import pandas as pd
+
 from occupational_classification._config.main import get_config
 from occupational_classification.data_access.soc_data_access import (
     load_soc_index,
@@ -191,30 +193,38 @@ class SOCRephraseLookup:
     rephrased or alternative descriptions to be matched to SOC codes.
 
     Attributes:
-        rephrase_dict (dict[str, str]): A dictionary mapping rephrased descriptions
-            to their corresponding SOC codes.
-        meta (SocMeta): Metadata for SOC classifications.
-
-    Methods:
-        rephrase_lookup(description: str) -> dict[str, Any]:
-            Looks up an SOC code based on a rephrased description.
-        add_rephrase_mapping(original: str, rephrased: str) -> None:
-            Adds a new rephrase mapping to the lookup dictionary.
+        data (pd.DataFrame): The SOC rephrase data loaded from a CSV file.
+        lookup_dict (dict[str, str]): A dictionary mapping SOC codes to rephrased descriptions.
     """
 
-    def __init__(self):
-        self.meta: SocMeta = SocMeta(structure_data_path = get_config()["data_source"]["soc_structure"])
+    def __init__(
+        self,
+        data_path: str = (
+            "src/occupational_classification/example_data/"
+            "example_rephrased_soc_data.csv"
+        ),
+    ):
+        """Initialise the SOCRephraseLookup with a rephrased SOC dataset.
 
-        self.lookup_dict: dict[str, str] = {
-            item["code"]: item["soc2020_group_title"] for item in self.meta.soc_meta
-        }
+        Args:
+            data_path: Path to the CSV file containing rephrased SOC descriptions.
+        """
+        # Load SOC rephrased descriptions and treat soc_code column as string
+        self.data: pd.DataFrame = pd.read_csv(data_path, dtype={"soc_code": str})
 
-    def lookup(self, soc_code: str) -> dict[str, Union[str, Any]]:
-        """Retrieve reviewed description for the given SOC code."""
+        # Create a lookup dictionary for quick access
+        self.lookup_dict: dict[str, str] = self.data.set_index("soc_code")[
+            "rephrased_description"
+        ].to_dict()
+
+    def lookup(self, soc_code: Union[str, int]) -> dict[str, Union[str, Any]]:
+        """Retrieve rephrased description for the given SOC code."""
+        soc_code = str(soc_code)
+
         if soc_code in self.lookup_dict:
             return {
                 "soc_code": soc_code,
-                "input_description": self.lookup_dict[soc_code],
+                "rephrased_description": self.lookup_dict[soc_code],
             }
 
         return {"soc_code": soc_code, "error": "SOC code not found"}
@@ -232,7 +242,7 @@ class SOCRephraseLookup:
 
         if rephrased_soc_description:
             input_json["soc_description"] = rephrased_soc_description[
-                "input_description"
+                "rephrased_description"
             ]
         else:
             input_json["soc_description"] = None
@@ -242,7 +252,7 @@ class SOCRephraseLookup:
             rephrased_descriptive = self.lookup(candidate["soc_code"])
             if rephrased_descriptive:
                 candidate["soc_descriptive"] = rephrased_descriptive[
-                    "input_description"
+                    "rephrased_description"
                 ]
 
         return input_json

--- a/src/occupational_classification/meta/soc_meta.py
+++ b/src/occupational_classification/meta/soc_meta.py
@@ -82,7 +82,7 @@ class SocDB:
         return pd.DataFrame(SocDB(self).create_soc_dictionary())
 
 
-class SocMeta:
+class SocMeta:  # pylint: disable=too-few-public-methods
     """SOC Meta data model class for SOC codes and their desriptions.
     Load and manage data related to SOC codes.
 

--- a/tests/test_data_access.py
+++ b/tests/test_data_access.py
@@ -1,3 +1,7 @@
+"""Tests for SOC data access utilities."""
+
+# pylint: disable=missing-function-docstring,redefined-outer-name,unused-argument
+
 from unittest.mock import patch
 
 import pandas as pd

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,4 +1,7 @@
-# pylint: disable=C0301
+"""Tests for SOCLookup and SOCRephraseLookup."""
+
+# pylint: disable=C0301,missing-function-docstring
+
 import pytest
 
 from src.occupational_classification.lookup import soc_lookup

--- a/tests/test_soc_data_structure.py
+++ b/tests/test_soc_data_structure.py
@@ -1,3 +1,7 @@
+"""Tests for SOC code, node, and hierarchy behaviour."""
+
+# pylint: disable=line-too-long,missing-function-docstring
+
 import pytest
 
 from src.occupational_classification.hierarchy import soc_hierarchy


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

Adds packaged SOC rephrase support to the library: a CSV dataset (`soc_code` → `rephrased_description`) and `SOCRephraseLookup` in `soc_lookup.py` to load it and expose `lookup(soc_code)` and `process_json()`. Consumed by `survey-assist-api` (which resolves the CSV via package data). 

Version bumped so dependants can pick up the extended example data - new release after approval

## 📜 Changes Introduced

- **Dataset**: `src/occupational_classification/example_data/example_rephrased_soc_data.csv` — initial rows (1111, 1112, 1121, 2136, 9233) plus 1131 and 3534 for Finance manager–style testing.
- **Lookup**: `src/occupational_classification/lookup/soc_lookup.py` — `SOCRephraseLookup` loads the CSV, builds a code→description map, and provides `lookup(soc_code)` and `process_json()` for rephrased descriptions.
- **Version**: `pyproject.toml` version bump for the rephrase dataset release.
- **Notebook**: `notebooks/soc_2025_05_01.py` — linting and clarity (docstring, formatting, print key results); rephrase example usage was pre-existing.

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

- **Unit tests**: `cd soc-classification-library && poetry run pytest -v`
- **Rephrase lookup**: In Python, `from occupational_classification.lookup.soc_lookup import SOCRephraseLookup` then `r = SOCRephraseLookup(); r.lookup("1131")` (should return rephrased description). CSV is loaded from package data by default.
- **End-to-end**: Use `survey-assist-api` with this library as a path dependency and run the SOC classify flow with `options.soc.rephrased` true/false; see survey-assist-api PR for curl commands.
