### PR TITLE
Sa 633/soc index and struct mandatory startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "soc-classification-library"
-version = "0.1.4"
+version = "0.1.5"
 description = "Standard Occupational Classification library"
 authors = ["Steve Gibbard <steve.gibbard@ons.gov.uk>"]
 license = "MIT"

--- a/src/occupational_classification/_config/config.toml
+++ b/src/occupational_classification/_config/config.toml
@@ -1,7 +1,10 @@
 [soc-classification-library]
 
 [data_source]
+# NOTE:
+# This section is read by get_config() and is the active source for soc_index/soc_structure paths.
+# Relative paths resolve from the current runtime working directory (for survey-assist-api Cloud Run: /app).
 
-soc_index = "../soc-classification-vector-store/src/soc_classification_vector_store/data/soc_index/soc2020volume2thecodingindexexcel16042025.xlsx"
+soc_index = "data/soc_index/soc2020volume2thecodingindexexcel16042025.xlsx"
 
-soc_structure = "../soc-classification-vector-store/src/soc_classification_vector_store/data/soc_index/soc2020volume1structureanddescriptionofunitgroupsexcel16042025.xlsx"
+soc_structure = "data/soc_index/soc2020volume1structureanddescriptionofunitgroupsexcel16042025.xlsx"


### PR DESCRIPTION
# 📌 Pull Request Template

## ✨ Summary

This PR updates SOC config data paths to resolve correctly in the `survey-assist-api` Cloud Run container while keeping `soc_index` and `soc_structure` mandatory at startup.

New v.0.1.5 release will be needed

Order of approval required:
1. This PR
2. https://github.com/ONSdigital/soc-classification-utils/pull/20
3. https://github.com/ONSdigital/survey-assist-api/pull/58


## 📜 Changes Introduced

- [x] Refactoring (chore:)
- [x] Updates to documentation/comments
- [ ] Terraform changes (if applicable)

- Updated `src/occupational_classification/_config/config.toml`:
  - `soc_index` -> `data/soc_index/soc2020volume2thecodingindexexcel16042025.xlsx`
  - `soc_structure` -> `data/soc_index/soc2020volume1structureanddescriptionofunitgroupsexcel16042025.xlsx`
- Added a brief note in `config.toml` clarifying that `[data_source]` is the active section and that relative paths resolve from runtime working directory.
- Bumped library version for release consumption by downstream repos.

## ✅ Checklist

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

1. In `soc-classification-library`, run:
   ```bash
   poetry run pytest
   ```
2.  Trigger a manual branch build with equivalent substitutions in `survey-assist-api` CI flow, ensure SOC workbooks are copied into `data/soc_index/` before Docker build (might n
3. Deploy and verify startup no longer fails with missing `soc_index`/`soc_structure` path errors.
